### PR TITLE
refactor: move loading bar completion logic to client plugin

### DIFF
--- a/frontend/app/middleware/loading.global.ts
+++ b/frontend/app/middleware/loading.global.ts
@@ -1,20 +1,9 @@
 export default defineNuxtRouteMiddleware((to, from) => {
-  const { start, done } = useLoadingBar();
+  const { start } = useLoadingBar();
 
   if (from.name && to.fullPath === from.fullPath) {
     return;
   }
 
-  // 在路由开始导航时启动加载条
   start();
-
-  if (import.meta.client) {
-    useRuntimeHook("page:finish", () => {
-      setTimeout(() => {
-        done();
-      }, 500);
-    });
-  }
-
-  // TODO: 路由加载出错时，也可以调用 `done()`
 });

--- a/frontend/app/plugins/loadingBar.client.ts
+++ b/frontend/app/plugins/loadingBar.client.ts
@@ -1,0 +1,9 @@
+export default defineNuxtPlugin(() => {
+  const { done } = useLoadingBar();
+
+  useRuntimeHook("page:finish", () => {
+    setTimeout(() => {
+      done();
+    }, 500);
+  });
+});


### PR DESCRIPTION
- Remove done() call from global middleware

- Add loadingBar.client plugin to handle page finish event