### PR TITLE
refactor(rss): improve RSS item struct with typed GUID and description

### DIFF
--- a/backend/internal/handler/rss_handler.go
+++ b/backend/internal/handler/rss_handler.go
@@ -21,7 +21,6 @@ func (r *rssHandler) Subscribe(c *fiber.Ctx) error {
 	}
 
 	c.Type("xml")
-	c.Append("Content-Disposition", "attachment; filename=rss.xml")
 	return c.Send(data)
 }
 

--- a/backend/internal/response/rss.go
+++ b/backend/internal/response/rss.go
@@ -16,11 +16,20 @@ type RssChannel struct {
 	Items       []RssItem `xml:"item"`
 }
 
+type RssItemDescription struct {
+	Value *string `xml:",cdata"`
+}
+
+type RssGUID struct {
+	Value       string `xml:",chardata"`
+	IsPermaLink bool   `xml:"isPermaLink,attr"`
+}
+
 type RssItem struct {
-	Title       string  `xml:"title"`
-	Content     string  `xml:"content"`
-	Link        string  `xml:"link"`
-	GUID        string  `xml:"guid"`
-	PubDate     string  `xml:"pubDate"`
-	Description *string `xml:"description"`
+	Title       string             `xml:"title"`
+	Content     string             `xml:"content"`
+	Link        string             `xml:"link"`
+	GUID        RssGUID            `xml:"guid"`
+	PubDate     string             `xml:"pubDate"`
+	Description RssItemDescription `xml:"description"`
 }

--- a/backend/internal/service/rss_service.go
+++ b/backend/internal/service/rss_service.go
@@ -47,9 +47,9 @@ func (r *rssService) GenerateRSSFeedXML(ctx context.Context) ([]byte, error) {
 		items[i] = response.RssItem{
 			Title:       post.Title,
 			Link:        link,
-			GUID:        link,
+			GUID:        response.RssGUID{Value: link, IsPermaLink: true},
 			PubDate:     pubDate,
-			Description: post.Summary,
+			Description: response.RssItemDescription{Value: post.Summary},
 		}
 	}
 


### PR DESCRIPTION
- Remove Content-Disposition header from response

- Use RssGUID and RssItemDescription types for better XML marshaling