### PR TITLE
refactor(database): redesign database interfaces and implementation

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -100,7 +100,7 @@ func runServerLifecycle(lc fx.Lifecycle, app *fiber.App, cfg *config.Config, log
 	})
 }
 
-func cleanupResources(ls fx.Lifecycle, db database.DB, rc cache.CacheClient) {
+func cleanupResources(ls fx.Lifecycle, db database.Database, rc cache.CacheClient) {
 	ls.Append(fx.Hook{
 		OnStop: func(ctx context.Context) error {
 			_ = db.Close()
@@ -114,7 +114,7 @@ func main() {
 	provider := fx.Provide(
 		logger.NewLogger,
 		provideConfig,
-		database.New,
+		database.NewGormDatabase,
 		cache.NewCacheClient,
 		validatorx.NewValidator,
 		providerFiberApp,

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -4,28 +4,23 @@ package database
 
 import (
 	"context"
-
-	"gorm.io/gorm"
 )
 
 type DB interface {
-	Trans(fn func(txc *TxContext) error) error
-	TransWithContext(ctx context.Context, fn func(txc *TxContext) error) error
-	Conn() *gorm.DB
+	isDB()
+}
+
+type Database interface {
+	DB
+	Trans(fn func(TxContext) error) error
+	TransWithContext(ctx context.Context, fn func(TxContext) error) error
 
 	Close() error
 	Ping() error
 }
 
-type TxContext struct {
-	tx  *gorm.DB
-	ctx context.Context
-}
-
-func (t *TxContext) GetTx() *gorm.DB {
-	return t.tx
-}
-
-func (t *TxContext) Ctx() context.Context {
-	return t.ctx
+type TxContext interface {
+	DB
+	// GetTx() Database
+	// Ctx() context.Context
 }

--- a/backend/database/gorm.go
+++ b/backend/database/gorm.go
@@ -4,17 +4,53 @@ import (
 	"context"
 
 	"blog-server/config"
+	"blog-server/errs"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
-type db struct {
+type GormDatabase struct {
 	db *gorm.DB
 }
 
-func New(cfg *config.Config) (DB, error) {
+type GormTxContext struct {
+	db *gorm.DB
+}
+
+func (d *GormDatabase) isDB()  {}
+func (t *GormTxContext) isDB() {}
+
+func (d *GormDatabase) Trans(fn func(TxContext) error) error {
+	return d.db.Transaction(func(tx *gorm.DB) error {
+		return fn(&GormTxContext{db: tx})
+	})
+}
+
+func (d *GormDatabase) TransWithContext(ctx context.Context, fn func(txc TxContext) error) error {
+	return d.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return fn(&GormTxContext{db: tx})
+	})
+}
+
+func (d *GormDatabase) Close() error {
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Close()
+}
+
+func (d *GormDatabase) Ping() error {
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.Ping()
+}
+
+func NewGormDatabase(cfg *config.Config) (Database, error) {
 	dsn := cfg.Database.GetDSN()
 	gormDB, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger:                                   logger.Default.LogMode(logger.Info),
@@ -35,37 +71,20 @@ func New(cfg *config.Config) (DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &db{db: gormDB}, nil
+	return &GormDatabase{db: gormDB}, nil
 }
 
-func (d *db) Trans(fn func(txc *TxContext) error) error {
-	return d.db.Transaction(func(tx *gorm.DB) error {
-		return fn(&TxContext{tx: tx})
-	})
+func NewGormTxContext(tx *gorm.DB) DB {
+	return &GormTxContext{db: tx}
 }
 
-func (d *db) TransWithContext(ctx context.Context, fn func(txc *TxContext) error) error {
-	return d.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		return fn(&TxContext{tx: tx, ctx: ctx})
-	})
-}
-
-func (d *db) Conn() *gorm.DB {
-	return d.db
-}
-
-func (d *db) Close() error {
-	sqlDB, err := d.db.DB()
-	if err != nil {
-		return err
+func ToGormDB(db DB) (*gorm.DB, error) {
+	switch v := db.(type) {
+	case *GormDatabase:
+		return v.db, nil
+	case *GormTxContext:
+		return v.db, nil
+	default:
+		return nil, errs.New(errs.CodeInternalError, "Invalid database type, please use GormDatabase or GormTxContext", nil)
 	}
-	return sqlDB.Close()
-}
-
-func (d *db) Ping() error {
-	sqlDB, err := d.db.DB()
-	if err != nil {
-		return err
-	}
-	return sqlDB.Ping()
 }

--- a/backend/repository/image.go
+++ b/backend/repository/image.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/errs"
 
@@ -13,33 +14,41 @@ import (
 )
 
 type IImageRepo interface {
-	Create(ctx context.Context, db *gorm.DB, image *entity.Image) error
-	GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID) (*entity.Image, error)
-	ListByFolder(ctx context.Context, db *gorm.DB, folderID *uuid.UUID, limit, offset int) ([]entity.Image, error)
-	Move(ctx context.Context, db *gorm.DB, id uuid.UUID, newFolderID *uuid.UUID) error
-	SoftDelete(ctx context.Context, db *gorm.DB, id uuid.UUID) error
-	CountByFolder(ctx context.Context, db *gorm.DB, folderID *uuid.UUID) (int64, error)
-	ExistsBySameNameInFolder(ctx context.Context, db *gorm.DB, folderID *uuid.UUID, name string, excludeID *uuid.UUID) (bool, error)
-	GetBySha256(ctx context.Context, db *gorm.DB, sha256 string) (*entity.Image, error)
+	Create(ctx context.Context, db database.DB, image *entity.Image) error
+	GetByID(ctx context.Context, db database.DB, id uuid.UUID) (*entity.Image, error)
+	ListByFolder(ctx context.Context, db database.DB, folderID *uuid.UUID, limit, offset int) ([]entity.Image, error)
+	Move(ctx context.Context, db database.DB, id uuid.UUID, newFolderID *uuid.UUID) error
+	SoftDelete(ctx context.Context, db database.DB, id uuid.UUID) error
+	CountByFolder(ctx context.Context, db database.DB, folderID *uuid.UUID) (int64, error)
+	ExistsBySameNameInFolder(ctx context.Context, db database.DB, folderID *uuid.UUID, name string, excludeID *uuid.UUID) (bool, error)
+	GetBySha256(ctx context.Context, db database.DB, sha256 string) (*entity.Image, error)
 }
 
 type imageRepo struct{}
 
-func (i *imageRepo) GetBySha256(ctx context.Context, db *gorm.DB, sha256 string) (*entity.Image, error) {
-	image, err := gorm.G[*entity.Image](db).
+func (i *imageRepo) GetBySha256(ctx context.Context, db database.DB, sha256 string) (*entity.Image, error) {
+	gdb := unwrapDB(db)
+
+	image, err := gorm.G[*entity.Image](gdb).
 		Where("sha256 = ? AND deleted_at IS NULL", sha256).
 		First(ctx)
+
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}
+
 	if err != nil {
 		return nil, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
-	return image, err
+
+	return image, nil
 }
 
-func (i *imageRepo) CountByFolder(ctx context.Context, db *gorm.DB, folderID *uuid.UUID) (int64, error) {
-	query := gorm.G[entity.Image](db).Where("deleted_at IS NULL")
+func (i *imageRepo) CountByFolder(ctx context.Context, db database.DB, folderID *uuid.UUID) (int64, error) {
+	gdb := unwrapDB(db)
+
+	query := gorm.G[entity.Image](gdb).Where("deleted_at IS NULL")
+
 	if folderID == nil {
 		query = query.Where("folder_id IS NULL")
 	} else {
@@ -50,32 +59,44 @@ func (i *imageRepo) CountByFolder(ctx context.Context, db *gorm.DB, folderID *uu
 	if err != nil {
 		return 0, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return count, nil
 }
 
-func (i *imageRepo) Create(ctx context.Context, db *gorm.DB, image *entity.Image) error {
+func (i *imageRepo) Create(ctx context.Context, db database.DB, image *entity.Image) error {
+	gdb := unwrapDB(db)
+
 	if image.ID == uuid.Nil {
 		image.ID = uuid.New()
 	}
+
 	now := time.Now()
+
 	if image.CreatedAt.IsZero() {
-		image.CreatedAt = time.Now()
+		image.CreatedAt = now
 	}
+
 	image.UpdatedAt = now
-	err := gorm.G[entity.Image](db).Create(ctx, image)
+
+	err := gorm.G[entity.Image](gdb).Create(ctx, image)
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 
-func (i *imageRepo) GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID) (*entity.Image, error) {
-	image, err := gorm.G[*entity.Image](db).
+func (i *imageRepo) GetByID(ctx context.Context, db database.DB, id uuid.UUID) (*entity.Image, error) {
+	gdb := unwrapDB(db)
+
+	image, err := gorm.G[*entity.Image](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		First(ctx)
+
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}
+
 	if err != nil {
 		return nil, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
@@ -83,13 +104,21 @@ func (i *imageRepo) GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID) (*en
 	return image, nil
 }
 
-func (i *imageRepo) ListByFolder(ctx context.Context, db *gorm.DB, folderID *uuid.UUID, limit int, offset int) ([]entity.Image, error) {
-	query := gorm.G[entity.Image](db).Where("deleted_at IS NULL")
+func (i *imageRepo) ListByFolder(
+	ctx context.Context,
+	db database.DB,
+	folderID *uuid.UUID,
+	limit int,
+	offset int,
+) ([]entity.Image, error) {
+	gdb := unwrapDB(db)
+
+	query := gorm.G[entity.Image](gdb).Where("deleted_at IS NULL")
 
 	if folderID == nil {
 		query = query.Where("folder_id IS NULL")
 	} else {
-		query = query.Where("folder_id = ?", folderID)
+		query = query.Where("folder_id = ?", *folderID)
 	}
 
 	if limit > 0 {
@@ -108,8 +137,15 @@ func (i *imageRepo) ListByFolder(ctx context.Context, db *gorm.DB, folderID *uui
 	return images, nil
 }
 
-func (i *imageRepo) Move(ctx context.Context, db *gorm.DB, id uuid.UUID, newFolderID *uuid.UUID) error {
-	_, err := gorm.G[entity.Image](db).
+func (i *imageRepo) Move(
+	ctx context.Context,
+	db database.DB,
+	id uuid.UUID,
+	newFolderID *uuid.UUID,
+) error {
+	gdb := unwrapDB(db)
+
+	_, err := gorm.G[entity.Image](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		Updates(ctx, entity.Image{
 			FolderID:  newFolderID,
@@ -118,17 +154,20 @@ func (i *imageRepo) Move(ctx context.Context, db *gorm.DB, id uuid.UUID, newFold
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 
 func (i *imageRepo) ExistsBySameNameInFolder(
 	ctx context.Context,
-	db *gorm.DB,
+	db database.DB,
 	folderID *uuid.UUID,
 	name string,
 	excludeID *uuid.UUID,
 ) (bool, error) {
-	q := gorm.G[entity.Image](db).
+	gdb := unwrapDB(db)
+
+	q := gorm.G[entity.Image](gdb).
 		Where("deleted_at IS NULL").
 		Where("origin_name = ?", name)
 
@@ -146,12 +185,20 @@ func (i *imageRepo) ExistsBySameNameInFolder(
 	if err != nil {
 		return false, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return count > 0, nil
 }
 
-func (i *imageRepo) SoftDelete(ctx context.Context, db *gorm.DB, id uuid.UUID) error {
+func (i *imageRepo) SoftDelete(
+	ctx context.Context,
+	db database.DB,
+	id uuid.UUID,
+) error {
+	gdb := unwrapDB(db)
+
 	now := time.Now()
-	_, err := gorm.G[entity.Image](db).
+
+	_, err := gorm.G[entity.Image](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		Updates(ctx, entity.Image{
 			DeletedAt: &now,
@@ -160,6 +207,7 @@ func (i *imageRepo) SoftDelete(ctx context.Context, db *gorm.DB, id uuid.UUID) e
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 

--- a/backend/repository/image_folder.go
+++ b/backend/repository/image_folder.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/errs"
 
@@ -13,62 +14,85 @@ import (
 )
 
 type IImageFolderRepo interface {
-	Create(ctx context.Context, db *gorm.DB, folder *entity.ImageFolder) error
-	GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID) (*entity.ImageFolder, error)
-	Exists(ctx context.Context, db *gorm.DB, id uuid.UUID) (bool, error)
-	ListByParent(ctx context.Context, db *gorm.DB, parentID *uuid.UUID, limit, offset int) ([]entity.ImageFolder, error)
-	ExistsBySameNameInParent(ctx context.Context, db *gorm.DB, parentID *uuid.UUID, name string, excludeID *uuid.UUID) (bool, error)
-	CountChildren(ctx context.Context, db *gorm.DB, parentID *uuid.UUID) (int64, error)
-	Rename(ctx context.Context, db *gorm.DB, id uuid.UUID, newName string) error
-	Move(ctx context.Context, db *gorm.DB, id uuid.UUID, newParentID *uuid.UUID) error
-	SoftDelete(ctx context.Context, db *gorm.DB, id uuid.UUID) error
+	Create(ctx context.Context, db database.DB, folder *entity.ImageFolder) error
+	GetByID(ctx context.Context, db database.DB, id uuid.UUID) (*entity.ImageFolder, error)
+	Exists(ctx context.Context, db database.DB, id uuid.UUID) (bool, error)
+	ListByParent(ctx context.Context, db database.DB, parentID *uuid.UUID, limit, offset int) ([]entity.ImageFolder, error)
+	ExistsBySameNameInParent(ctx context.Context, db database.DB, parentID *uuid.UUID, name string, excludeID *uuid.UUID) (bool, error)
+	CountChildren(ctx context.Context, db database.DB, parentID *uuid.UUID) (int64, error)
+	Rename(ctx context.Context, db database.DB, id uuid.UUID, newName string) error
+	Move(ctx context.Context, db database.DB, id uuid.UUID, newParentID *uuid.UUID) error
+	SoftDelete(ctx context.Context, db database.DB, id uuid.UUID) error
 }
 
 type imageFolderRepo struct{}
 
-func (i *imageFolderRepo) CountChildren(ctx context.Context, db *gorm.DB, parentID *uuid.UUID) (int64, error) {
-	query := gorm.G[entity.ImageFolder](db).
+func (i *imageFolderRepo) CountChildren(ctx context.Context, db database.DB, parentID *uuid.UUID) (int64, error) {
+	gdb := unwrapDB(db)
+
+	query := gorm.G[entity.ImageFolder](gdb).
 		Where("deleted_at IS NULL")
+
 	if parentID != nil {
-		query.Where("parent_id = ?", parentID)
+		query = query.Where("parent_id = ?", parentID)
 	} else {
-		query.Where("parent_id IS NULL")
+		query = query.Where("parent_id IS NULL")
 	}
+
 	count, err := query.Count(ctx, "id")
 	if err != nil {
 		return 0, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return count, nil
 }
 
-func (i *imageFolderRepo) Create(ctx context.Context, db *gorm.DB, folder *entity.ImageFolder) error {
+func (i *imageFolderRepo) Create(ctx context.Context, db database.DB, folder *entity.ImageFolder) error {
+	gdb := unwrapDB(db)
+
 	if folder.ID == uuid.Nil {
 		folder.ID = uuid.New()
 	}
+
 	now := time.Now()
+
 	if folder.CreatedAt.IsZero() {
-		folder.CreatedAt = time.Now()
+		folder.CreatedAt = now
 	}
+
 	folder.UpdatedAt = now
-	err := gorm.G[entity.ImageFolder](db).Create(ctx, folder)
+
+	err := gorm.G[entity.ImageFolder](gdb).Create(ctx, folder)
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 
-func (i *imageFolderRepo) Exists(ctx context.Context, db *gorm.DB, id uuid.UUID) (bool, error) {
-	count, err := gorm.G[entity.ImageFolder](db).
+func (i *imageFolderRepo) Exists(ctx context.Context, db database.DB, id uuid.UUID) (bool, error) {
+	gdb := unwrapDB(db)
+
+	count, err := gorm.G[entity.ImageFolder](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		Count(ctx, "id")
 	if err != nil {
 		return false, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return count > 0, nil
 }
 
-func (i *imageFolderRepo) ExistsBySameNameInParent(ctx context.Context, db *gorm.DB, parentID *uuid.UUID, name string, excludeID *uuid.UUID) (bool, error) {
-	query := gorm.G[entity.ImageFolder](db).
+func (i *imageFolderRepo) ExistsBySameNameInParent(
+	ctx context.Context,
+	db database.DB,
+	parentID *uuid.UUID,
+	name string,
+	excludeID *uuid.UUID,
+) (bool, error) {
+	gdb := unwrapDB(db)
+
+	query := gorm.G[entity.ImageFolder](gdb).
 		Where("deleted_at IS NULL").
 		Where("name = ?", name)
 
@@ -86,16 +110,21 @@ func (i *imageFolderRepo) ExistsBySameNameInParent(ctx context.Context, db *gorm
 	if err != nil {
 		return false, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return count > 0, nil
 }
 
-func (i *imageFolderRepo) GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID) (*entity.ImageFolder, error) {
-	folder, err := gorm.G[*entity.ImageFolder](db).
+func (i *imageFolderRepo) GetByID(ctx context.Context, db database.DB, id uuid.UUID) (*entity.ImageFolder, error) {
+	gdb := unwrapDB(db)
+
+	folder, err := gorm.G[*entity.ImageFolder](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		First(ctx)
+
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, nil
 	}
+
 	if err != nil {
 		return nil, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
@@ -103,8 +132,16 @@ func (i *imageFolderRepo) GetByID(ctx context.Context, db *gorm.DB, id uuid.UUID
 	return folder, nil
 }
 
-func (i *imageFolderRepo) ListByParent(ctx context.Context, db *gorm.DB, parentID *uuid.UUID, limit int, offset int) ([]entity.ImageFolder, error) {
-	query := gorm.G[entity.ImageFolder](db).Where("deleted_at IS NULL")
+func (i *imageFolderRepo) ListByParent(
+	ctx context.Context,
+	db database.DB,
+	parentID *uuid.UUID,
+	limit int,
+	offset int,
+) ([]entity.ImageFolder, error) {
+	gdb := unwrapDB(db)
+
+	query := gorm.G[entity.ImageFolder](gdb).Where("deleted_at IS NULL")
 
 	if parentID == nil {
 		query = query.Where("parent_id IS NULL")
@@ -124,11 +161,19 @@ func (i *imageFolderRepo) ListByParent(ctx context.Context, db *gorm.DB, parentI
 	if err != nil {
 		return nil, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return result, nil
 }
 
-func (i *imageFolderRepo) Move(ctx context.Context, db *gorm.DB, id uuid.UUID, newParentID *uuid.UUID) error {
-	_, err := gorm.G[entity.ImageFolder](db).
+func (i *imageFolderRepo) Move(
+	ctx context.Context,
+	db database.DB,
+	id uuid.UUID,
+	newParentID *uuid.UUID,
+) error {
+	gdb := unwrapDB(db)
+
+	_, err := gorm.G[entity.ImageFolder](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		Updates(ctx, entity.ImageFolder{
 			ParentID:  newParentID,
@@ -137,11 +182,19 @@ func (i *imageFolderRepo) Move(ctx context.Context, db *gorm.DB, id uuid.UUID, n
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 
-func (i *imageFolderRepo) Rename(ctx context.Context, db *gorm.DB, id uuid.UUID, newName string) error {
-	_, err := gorm.G[entity.ImageFolder](db).
+func (i *imageFolderRepo) Rename(
+	ctx context.Context,
+	db database.DB,
+	id uuid.UUID,
+	newName string,
+) error {
+	gdb := unwrapDB(db)
+
+	_, err := gorm.G[entity.ImageFolder](gdb).
 		Where("id = ?", id).
 		Updates(ctx, entity.ImageFolder{
 			Name:      newName,
@@ -150,12 +203,20 @@ func (i *imageFolderRepo) Rename(ctx context.Context, db *gorm.DB, id uuid.UUID,
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 
-func (i *imageFolderRepo) SoftDelete(ctx context.Context, db *gorm.DB, id uuid.UUID) error {
+func (i *imageFolderRepo) SoftDelete(
+	ctx context.Context,
+	db database.DB,
+	id uuid.UUID,
+) error {
+	gdb := unwrapDB(db)
+
 	now := time.Now()
-	_, err := gorm.G[entity.ImageFolder](db).
+
+	_, err := gorm.G[entity.ImageFolder](gdb).
 		Where("id = ? AND deleted_at IS NULL", id).
 		Updates(ctx, entity.ImageFolder{
 			DeletedAt: &now,
@@ -164,6 +225,7 @@ func (i *imageFolderRepo) SoftDelete(ctx context.Context, db *gorm.DB, id uuid.U
 	if err != nil {
 		return errs.New(errs.CodeDatabaseError, "database error", err)
 	}
+
 	return nil
 }
 

--- a/backend/repository/image_folder_test.go
+++ b/backend/repository/image_folder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/test"
 
@@ -16,7 +17,7 @@ import (
 	"gorm.io/gorm/logger"
 )
 
-func newTestDB(t *testing.T) (*gorm.DB, func()) {
+func newTestDB(t *testing.T) (database.DB, func()) {
 	t.Helper()
 
 	cfg, err := test.LoadConfig()
@@ -40,23 +41,25 @@ func newTestDB(t *testing.T) (*gorm.DB, func()) {
 
 	tx := db.Begin()
 	require.NoError(t, tx.Error)
+
 	require.NoError(t, tx.Session(&gorm.Session{
 		Logger: tx.Logger.LogMode(logger.Silent),
 	}).AutoMigrate(&entity.ImageFolder{}))
 
-	// 默认每个 test 用事务隔离，结束时回滚
+	// 用 TxContext 包装
+	txCtx := database.NewGormTxContext(tx)
 	cleanup := func() {
 		_ = tx.Rollback().Error
 	}
+
 	t.Cleanup(cleanup)
 
-	return tx, func() {
-		// 允许个别 test 选择提交
+	return txCtx, func() {
 		_ = tx.Commit().Error
 	}
 }
 
-func mustCreateFolder(t *testing.T, ctx context.Context, db *gorm.DB, repo IImageFolderRepo, name string, parentID *uuid.UUID) *entity.ImageFolder {
+func mustCreateFolder(t *testing.T, ctx context.Context, db database.DB, repo IImageFolderRepo, name string, parentID *uuid.UUID) *entity.ImageFolder {
 	t.Helper()
 
 	f := &entity.ImageFolder{

--- a/backend/repository/link.go
+++ b/backend/repository/link.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/errs"
 	"blog-server/response"
@@ -15,11 +16,11 @@ import (
 
 // ILinkRepo defines the interface for link data access operations
 type ILinkRepo interface {
-	GetAllLinks(ctx context.Context, db *gorm.DB) ([]*entity.Link, error)
-	GetAllEnabledLinks(ctx context.Context, db *gorm.DB) ([]*entity.Link, error)
-	CreateLink(ctx context.Context, db *gorm.DB, link *entity.Link) error
-	UpdateLinkStatusBatch(ctx context.Context, db *gorm.DB, updates map[uint]entity.LinkStatus) error
-	GetOverview(ctx context.Context, db *gorm.DB) (*response.LinkOverview, error)
+	GetAllLinks(ctx context.Context, db database.DB) ([]*entity.Link, error)
+	GetAllEnabledLinks(ctx context.Context, db database.DB) ([]*entity.Link, error)
+	CreateLink(ctx context.Context, db database.DB, link *entity.Link) error
+	UpdateLinkStatusBatch(ctx context.Context, db database.DB, updates map[uint]entity.LinkStatus) error
+	GetOverview(ctx context.Context, db database.DB) (*response.LinkOverview, error)
 }
 
 type linkRepo struct{}
@@ -30,8 +31,10 @@ func NewLinkRepo() ILinkRepo {
 }
 
 // GetAllLinks retrieves all links from the database
-func (r *linkRepo) GetAllLinks(ctx context.Context, db *gorm.DB) ([]*entity.Link, error) {
-	links, err := gorm.G[*entity.Link](db).
+func (r *linkRepo) GetAllLinks(ctx context.Context, db database.DB) ([]*entity.Link, error) {
+	gdb := unwrapDB(db)
+
+	links, err := gorm.G[*entity.Link](gdb).
 		Where("deleted_at IS NULL").
 		Find(ctx)
 	if err != nil {
@@ -41,8 +44,10 @@ func (r *linkRepo) GetAllLinks(ctx context.Context, db *gorm.DB) ([]*entity.Link
 }
 
 // GetAllEnabledLinks retrieves all enabled links from the database
-func (r *linkRepo) GetAllEnabledLinks(ctx context.Context, db *gorm.DB) ([]*entity.Link, error) {
-	links, err := gorm.G[*entity.Link](db).
+func (r *linkRepo) GetAllEnabledLinks(ctx context.Context, db database.DB) ([]*entity.Link, error) {
+	gdb := unwrapDB(db)
+
+	links, err := gorm.G[*entity.Link](gdb).
 		Where("enabled = ? AND deleted_at IS NULL", true).
 		Find(ctx)
 	if err != nil {
@@ -52,8 +57,9 @@ func (r *linkRepo) GetAllEnabledLinks(ctx context.Context, db *gorm.DB) ([]*enti
 }
 
 // CreateLink creates a new link in the database
-func (r *linkRepo) CreateLink(ctx context.Context, db *gorm.DB, link *entity.Link) error {
-	if err := gorm.G[entity.Link](db).Create(ctx, link); err != nil {
+func (r *linkRepo) CreateLink(ctx context.Context, db database.DB, link *entity.Link) error {
+	gdb := unwrapDB(db)
+	if err := gorm.G[entity.Link](gdb).Create(ctx, link); err != nil {
 		if errors.Is(err, gorm.ErrDuplicatedKey) {
 			return errs.New(errs.CodeConflict, "link already exists", err)
 		}
@@ -63,7 +69,8 @@ func (r *linkRepo) CreateLink(ctx context.Context, db *gorm.DB, link *entity.Lin
 }
 
 // UpdateLinkStatusBatch batch updates the status of multiple links
-func (r *linkRepo) UpdateLinkStatusBatch(ctx context.Context, db *gorm.DB, updates map[uint]entity.LinkStatus) error {
+func (r *linkRepo) UpdateLinkStatusBatch(ctx context.Context, db database.DB, updates map[uint]entity.LinkStatus) error {
+	gdb := unwrapDB(db)
 	if len(updates) == 0 {
 		return nil
 	}
@@ -80,7 +87,7 @@ func (r *linkRepo) UpdateLinkStatusBatch(ctx context.Context, db *gorm.DB, updat
 	}
 	caseBuilder.WriteString("ELSE status END")
 
-	err := db.Model(&entity.Link{}).
+	err := gdb.Model(&entity.Link{}).
 		Where("id IN (?)", ids).
 		UpdateColumn("status", gorm.Expr(caseBuilder.String(), idArgs...)).Error
 	if err != nil {
@@ -90,7 +97,8 @@ func (r *linkRepo) UpdateLinkStatusBatch(ctx context.Context, db *gorm.DB, updat
 }
 
 // GetOverview retrieves link statistics including total, normal, abnormal, and pending counts
-func (r *linkRepo) GetOverview(ctx context.Context, db *gorm.DB) (*response.LinkOverview, error) {
+func (r *linkRepo) GetOverview(ctx context.Context, db database.DB) (*response.LinkOverview, error) {
+	gdb := unwrapDB(db)
 	type result struct {
 		Total   int
 		Normal  int
@@ -98,7 +106,7 @@ func (r *linkRepo) GetOverview(ctx context.Context, db *gorm.DB) (*response.Link
 	}
 
 	var res result
-	err := db.Table("links").
+	err := gdb.Table("links").
 		Select(
 			"count(id) as total, "+
 				"sum(case when status = ? then 1 else 0 end) as normal, "+

--- a/backend/repository/post.go
+++ b/backend/repository/post.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/errs"
 
@@ -14,12 +15,12 @@ import (
 
 // IPostRepo defines the interface for post data access operations
 type IPostRepo interface {
-	GetAllPosts(ctx context.Context, db *gorm.DB) ([]*entity.Post, error)
-	GetAllPostsWithContent(ctx context.Context, db *gorm.DB) ([]*entity.Post, error)
-	GetPostsMeta(ctx context.Context, db *gorm.DB) ([]*entity.Post, error)
-	GetPostCount(ctx context.Context, db *gorm.DB) (int64, error)
-	GetPostByID(ctx context.Context, db *gorm.DB, id uint) (*entity.Post, error)
-	UpdateViewCounts(ctx context.Context, db *gorm.DB, updates map[uint]int64) error
+	GetAllPosts(ctx context.Context, db database.DB) ([]*entity.Post, error)
+	GetAllPostsWithContent(ctx context.Context, db database.DB) ([]*entity.Post, error)
+	GetPostsMeta(ctx context.Context, db database.DB) ([]*entity.Post, error)
+	GetPostCount(ctx context.Context, db database.DB) (int64, error)
+	GetPostByID(ctx context.Context, db database.DB, id uint) (*entity.Post, error)
+	UpdateViewCounts(ctx context.Context, db database.DB, updates map[uint]int64) error
 }
 
 type postRepo struct{}
@@ -30,8 +31,9 @@ func NewPostRepo() IPostRepo {
 }
 
 // GetAllPosts retrieves all published posts without content
-func (r *postRepo) GetAllPosts(ctx context.Context, db *gorm.DB) ([]*entity.Post, error) {
-	posts, err := gorm.G[*entity.Post](db).
+func (r *postRepo) GetAllPosts(ctx context.Context, db database.DB) ([]*entity.Post, error) {
+	gdb := unwrapDB(db)
+	posts, err := gorm.G[*entity.Post](gdb).
 		Joins(clause.JoinTarget{Association: "User"}, func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 			db.Select("username")
 			return nil
@@ -56,8 +58,9 @@ func (r *postRepo) GetAllPosts(ctx context.Context, db *gorm.DB) ([]*entity.Post
 }
 
 // GetAllPostsWithContent retrieves all published posts with full content
-func (r *postRepo) GetAllPostsWithContent(ctx context.Context, db *gorm.DB) ([]*entity.Post, error) {
-	posts, err := gorm.G[*entity.Post](db).
+func (r *postRepo) GetAllPostsWithContent(ctx context.Context, db database.DB) ([]*entity.Post, error) {
+	gdb := unwrapDB(db)
+	posts, err := gorm.G[*entity.Post](gdb).
 		Joins(clause.JoinTarget{Association: "User"}, func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 			db.Select("username")
 			return nil
@@ -83,8 +86,9 @@ func (r *postRepo) GetAllPostsWithContent(ctx context.Context, db *gorm.DB) ([]*
 }
 
 // GetPostsMeta retrieves metadata (id and updated_at) for all posts
-func (r *postRepo) GetPostsMeta(ctx context.Context, db *gorm.DB) ([]*entity.Post, error) {
-	posts, err := gorm.G[*entity.Post](db).
+func (r *postRepo) GetPostsMeta(ctx context.Context, db database.DB) ([]*entity.Post, error) {
+	gdb := unwrapDB(db)
+	posts, err := gorm.G[*entity.Post](gdb).
 		Select("id", "updated_at").
 		Where("deleted_at IS NULL").
 		Find(ctx)
@@ -95,8 +99,9 @@ func (r *postRepo) GetPostsMeta(ctx context.Context, db *gorm.DB) ([]*entity.Pos
 }
 
 // GetPostCount returns the total count of posts
-func (r *postRepo) GetPostCount(ctx context.Context, db *gorm.DB) (int64, error) {
-	postCount, err := gorm.G[*entity.Post](db).
+func (r *postRepo) GetPostCount(ctx context.Context, db database.DB) (int64, error) {
+	gdb := unwrapDB(db)
+	postCount, err := gorm.G[*entity.Post](gdb).
 		Where("deleted_at IS NULL").
 		Count(ctx, "id")
 	if err != nil {
@@ -106,8 +111,9 @@ func (r *postRepo) GetPostCount(ctx context.Context, db *gorm.DB) (int64, error)
 }
 
 // GetPostByID retrieves a single published post by ID
-func (r *postRepo) GetPostByID(ctx context.Context, db *gorm.DB, id uint) (*entity.Post, error) {
-	post, err := gorm.G[*entity.Post](db).
+func (r *postRepo) GetPostByID(ctx context.Context, db database.DB, id uint) (*entity.Post, error) {
+	gdb := unwrapDB(db)
+	post, err := gorm.G[*entity.Post](gdb).
 		Joins(clause.JoinTarget{Association: "User"}, func(db gorm.JoinBuilder, joinTable clause.Table, curTable clause.Table) error {
 			db.Select("username")
 			return nil
@@ -137,7 +143,9 @@ func (r *postRepo) GetPostByID(ctx context.Context, db *gorm.DB, id uint) (*enti
 }
 
 // UpdateViewCounts batch updates view counts for multiple posts
-func (r *postRepo) UpdateViewCounts(ctx context.Context, db *gorm.DB, updates map[uint]int64) error {
+func (r *postRepo) UpdateViewCounts(ctx context.Context, db database.DB, updates map[uint]int64) error {
+	gdb := unwrapDB(db)
+
 	if len(updates) == 0 {
 		return nil
 	}
@@ -154,7 +162,7 @@ func (r *postRepo) UpdateViewCounts(ctx context.Context, db *gorm.DB, updates ma
 	}
 	caseBuilder.WriteString("ELSE 0 END")
 
-	err := db.Model(&entity.Post{}).
+	err := gdb.Model(&entity.Post{}).
 		Where("id IN (?)", ids).
 		UpdateColumn("view_count", gorm.Expr(caseBuilder.String(), idArgs...)).Error
 	if err != nil {

--- a/backend/repository/repo.go
+++ b/backend/repository/repo.go
@@ -5,13 +5,15 @@ import (
 	"context"
 	"errors"
 
+	"blog-server/database"
 	"blog-server/errs"
 
 	"gorm.io/gorm"
 )
 
-func ExistsBy[T any](ctx context.Context, db *gorm.DB, field string, value any) (bool, error) {
-	_, err := gorm.G[*T](db).Where(field+" = ?", value).Take(ctx)
+func existsBy[T any](ctx context.Context, db database.DB, field string, value any) (bool, error) {
+	gdb := unwrapDB(db)
+	_, err := gorm.G[*T](gdb).Where(field+" = ?", value).Take(ctx)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return false, nil
 	}
@@ -19,4 +21,12 @@ func ExistsBy[T any](ctx context.Context, db *gorm.DB, field string, value any) 
 		return false, errs.New(errs.CodeDatabaseError, "database error", err)
 	}
 	return true, nil
+}
+
+func unwrapDB(db database.DB) *gorm.DB {
+	gdb, err := database.ToGormDB(db)
+	if err != nil {
+		panic(err)
+	}
+	return gdb
 }

--- a/backend/repository/user.go
+++ b/backend/repository/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"blog-server/database"
 	"blog-server/entity"
 	"blog-server/errs"
 
@@ -12,12 +13,12 @@ import (
 
 // IUserRepo defines the interface for user data access operations
 type IUserRepo interface {
-	GetUserByEmail(ctx context.Context, db *gorm.DB, email string) (*entity.User, error)
-	CreateUser(ctx context.Context, db *gorm.DB, user *entity.User) (*entity.User, error)
-	ExistsByEmail(ctx context.Context, db *gorm.DB, email string) (bool, error)
-	ExistsByID(ctx context.Context, db *gorm.DB, id uint) (bool, error)
-	ExistsByUUID(ctx context.Context, db *gorm.DB, uuid string) (bool, error)
-	GetRoleByUUID(ctx context.Context, db *gorm.DB, uuid string) (*entity.UserRole, error)
+	GetUserByEmail(ctx context.Context, db database.DB, email string) (*entity.User, error)
+	CreateUser(ctx context.Context, db database.DB, user *entity.User) (*entity.User, error)
+	ExistsByEmail(ctx context.Context, db database.DB, email string) (bool, error)
+	ExistsByID(ctx context.Context, db database.DB, id uint) (bool, error)
+	ExistsByUUID(ctx context.Context, db database.DB, uuid string) (bool, error)
+	GetRoleByUUID(ctx context.Context, db database.DB, uuid string) (*entity.UserRole, error)
 }
 
 type userRepo struct{}
@@ -28,9 +29,10 @@ func NewUserRepo() IUserRepo {
 }
 
 // CreateUser creates a new user in the database
-func (u *userRepo) CreateUser(ctx context.Context, db *gorm.DB, user *entity.User) (*entity.User, error) {
+func (u *userRepo) CreateUser(ctx context.Context, db database.DB, user *entity.User) (*entity.User, error) {
+	gdb := unwrapDB(db)
 	result := gorm.WithResult()
-	err := gorm.G[entity.User](db, result).Create(ctx, user)
+	err := gorm.G[entity.User](gdb, result).Create(ctx, user)
 	if errors.Is(err, gorm.ErrDuplicatedKey) {
 		return nil, errs.New(errs.CodeUserAlreadyExists, "user already exists", err)
 	}
@@ -41,8 +43,9 @@ func (u *userRepo) CreateUser(ctx context.Context, db *gorm.DB, user *entity.Use
 }
 
 // GetUserByEmail retrieves a user by email address
-func (u *userRepo) GetUserByEmail(ctx context.Context, db *gorm.DB, email string) (*entity.User, error) {
-	user, err := gorm.G[*entity.User](db).
+func (u *userRepo) GetUserByEmail(ctx context.Context, db database.DB, email string) (*entity.User, error) {
+	gdb := unwrapDB(db)
+	user, err := gorm.G[*entity.User](gdb).
 		Where("email = ?", email).
 		Where("deleted_at IS NULL").
 		Take(ctx)
@@ -56,23 +59,24 @@ func (u *userRepo) GetUserByEmail(ctx context.Context, db *gorm.DB, email string
 }
 
 // ExistsByEmail checks if a user exists by email
-func (u *userRepo) ExistsByEmail(ctx context.Context, db *gorm.DB, email string) (bool, error) {
-	return ExistsBy[entity.User](ctx, db, "email", email)
+func (u *userRepo) ExistsByEmail(ctx context.Context, db database.DB, email string) (bool, error) {
+	return existsBy[entity.User](ctx, db, "email", email)
 }
 
 // ExistsByID checks if a user exists by ID
-func (u *userRepo) ExistsByID(ctx context.Context, db *gorm.DB, id uint) (bool, error) {
-	return ExistsBy[entity.User](ctx, db, "id", id)
+func (u *userRepo) ExistsByID(ctx context.Context, db database.DB, id uint) (bool, error) {
+	return existsBy[entity.User](ctx, db, "id", id)
 }
 
 // ExistsByUUID checks if a user exists by UUID
-func (u *userRepo) ExistsByUUID(ctx context.Context, db *gorm.DB, uuid string) (bool, error) {
-	return ExistsBy[entity.User](ctx, db, "uuid", uuid)
+func (u *userRepo) ExistsByUUID(ctx context.Context, db database.DB, uuid string) (bool, error) {
+	return existsBy[entity.User](ctx, db, "uuid", uuid)
 }
 
 // GetRoleByUUID retrieves the user role by UUID
-func (u *userRepo) GetRoleByUUID(ctx context.Context, db *gorm.DB, uuid string) (*entity.UserRole, error) {
-	role, err := gorm.G[*entity.UserRole](db).
+func (u *userRepo) GetRoleByUUID(ctx context.Context, db database.DB, uuid string) (*entity.UserRole, error) {
+	gdb := unwrapDB(db)
+	role, err := gorm.G[*entity.UserRole](gdb).
 		Where("uuid = ?", uuid).
 		Where("deleted_at IS NULL").
 		Take(ctx)

--- a/backend/service/auth.go
+++ b/backend/service/auth.go
@@ -53,7 +53,7 @@ type IAuthService interface {
 
 // AuthService implements the IAuthService interface
 type AuthService struct {
-	db          database.DB
+	db          database.Database
 	rc          cache.CacheClient
 	cfg         *config.Config
 	userRepo    repository.IUserRepo
@@ -62,7 +62,7 @@ type AuthService struct {
 }
 
 // NewAuthService creates and returns a new AuthService instance
-func NewAuthService(db database.DB, rc cache.CacheClient, userRepo repository.IUserRepo, jwtService IJwtService, mailService IMailService) IAuthService {
+func NewAuthService(db database.Database, rc cache.CacheClient, userRepo repository.IUserRepo, jwtService IJwtService, mailService IMailService) IAuthService {
 	return &AuthService{
 		db:          db,
 		rc:          rc,
@@ -97,8 +97,8 @@ func (s *AuthService) Register(ctx context.Context, dto *request.RegisterReq) (*
 
 	var newUser *entity.User
 
-	err = s.db.Trans(func(txCtx *database.TxContext) error {
-		newUser, err = s.userRepo.CreateUser(ctx, txCtx.GetTx(), user)
+	err = s.db.Trans(func(txCtx database.TxContext) error {
+		newUser, err = s.userRepo.CreateUser(ctx, txCtx, user)
 		if err != nil {
 			return errs.New(errs.CodeDatabaseError, "Create user failed", err)
 		}
@@ -131,7 +131,7 @@ func (s *AuthService) Register(ctx context.Context, dto *request.RegisterReq) (*
 
 // Login logs in a user and generates access/refresh tokens
 func (s *AuthService) Login(ctx context.Context, dto *request.LoginReq) (*response.LoginRes, error) {
-	user, err := s.userRepo.GetUserByEmail(ctx, s.db.Conn(), dto.Email)
+	user, err := s.userRepo.GetUserByEmail(ctx, s.db, dto.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *AuthService) Login(ctx context.Context, dto *request.LoginReq) (*respon
 
 // SendCaptchaMail generates a captcha, stores it in Redis, and sends an email
 func (s *AuthService) SendCaptchaMail(ctx context.Context, to string, captchaType CaptchaType) error {
-	userExists, err := s.userRepo.ExistsByEmail(ctx, s.db.Conn(), to)
+	userExists, err := s.userRepo.ExistsByEmail(ctx, s.db, to)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, token string) (*re
 	}
 	uuid := claims.UserID
 
-	existed, err := s.userRepo.ExistsByUUID(ctx, s.db.Conn(), uuid)
+	existed, err := s.userRepo.ExistsByUUID(ctx, s.db, uuid)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +236,7 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, token string) (*re
 
 // HasRole checks if a user has any of the specified roles
 func (s *AuthService) HasRole(ctx context.Context, uuid string, roles ...entity.UserRole) (bool, error) {
-	userRole, err := s.userRepo.GetRoleByUUID(ctx, s.db.Conn(), uuid)
+	userRole, err := s.userRepo.GetRoleByUUID(ctx, s.db, uuid)
 	if err != nil {
 		return false, err
 	}

--- a/backend/service/image.go
+++ b/backend/service/image.go
@@ -27,7 +27,7 @@ type IImageService interface {
 }
 
 type imageService struct {
-	db         database.DB
+	db         database.Database
 	store      storage.Storage
 	bucket     string
 	folderRepo repository.IImageFolderRepo
@@ -61,7 +61,7 @@ func (i *imageService) Upload(ctx context.Context, folderID *uuid.UUID, filename
 	}
 
 	if folderID != nil {
-		ok, err := i.folderRepo.Exists(ctx, i.db.Conn(), *folderID)
+		ok, err := i.folderRepo.Exists(ctx, i.db, *folderID)
 		if err != nil {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ func (i *imageService) Upload(ctx context.Context, folderID *uuid.UUID, filename
 	ext := strings.ToLower(filepath.Ext(filename))
 	finalKey := fmt.Sprintf("%s/%s%s", hashHex[:2], hashHex, ext)
 
-	exist, err := i.imageRepo.GetBySha256(ctx, i.db.Conn(), hashHex)
+	exist, err := i.imageRepo.GetBySha256(ctx, i.db, hashHex)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (i *imageService) Upload(ctx context.Context, folderID *uuid.UUID, filename
 			CreatedAt:  now,
 			UpdatedAt:  now,
 		}
-		if err := i.imageRepo.Create(ctx, i.db.Conn(), img); err != nil {
+		if err := i.imageRepo.Create(ctx, i.db, img); err != nil {
 			return nil, err
 		}
 		return img, nil
@@ -147,12 +147,12 @@ func (i *imageService) Upload(ctx context.Context, folderID *uuid.UUID, filename
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}
-	if err := i.imageRepo.Create(ctx, i.db.Conn(), img); err != nil {
+	if err := i.imageRepo.Create(ctx, i.db, img); err != nil {
 		return nil, err
 	}
 	return img, nil
 }
 
-func NewImageService(db database.DB, storage storage.Storage, folderRepo repository.IImageFolderRepo, imageRepo repository.IImageRepo) IImageService {
+func NewImageService(db database.Database, storage storage.Storage, folderRepo repository.IImageFolderRepo, imageRepo repository.IImageRepo) IImageService {
 	return &imageService{db: db, store: storage, bucket: "images", folderRepo: folderRepo, imageRepo: imageRepo}
 }

--- a/backend/service/image_folder.go
+++ b/backend/service/image_folder.go
@@ -22,7 +22,7 @@ type IImageFolderService interface {
 }
 
 type imageFolderService struct {
-	db              database.DB
+	db              database.Database
 	imageFolderRepo repository.IImageFolderRepo
 }
 
@@ -31,7 +31,7 @@ func normalizeName(name string) string {
 }
 
 func (s *imageFolderService) ensureFolderExists(ctx context.Context, id uuid.UUID) (*entity.ImageFolder, error) {
-	folder, err := s.imageFolderRepo.GetByID(ctx, s.db.Conn(), id)
+	folder, err := s.imageFolderRepo.GetByID(ctx, s.db, id)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (s *imageFolderService) ensureParentExists(ctx context.Context, parentID *u
 	if parentID == nil {
 		return nil
 	}
-	ok, err := s.imageFolderRepo.Exists(ctx, s.db.Conn(), *parentID)
+	ok, err := s.imageFolderRepo.Exists(ctx, s.db, *parentID)
 	if err != nil {
 		return err
 	}
@@ -56,7 +56,7 @@ func (s *imageFolderService) ensureParentExists(ctx context.Context, parentID *u
 }
 
 func (s *imageFolderService) ensureNoDuplicateName(ctx context.Context, parentID *uuid.UUID, name string, excludeID *uuid.UUID) error {
-	dup, err := s.imageFolderRepo.ExistsBySameNameInParent(ctx, s.db.Conn(), parentID, name, excludeID)
+	dup, err := s.imageFolderRepo.ExistsBySameNameInParent(ctx, s.db, parentID, name, excludeID)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func (s *imageFolderService) Create(ctx context.Context, name string, parentID *
 		ParentID: parentID,
 		Name:     name,
 	}
-	if err := s.imageFolderRepo.Create(ctx, s.db.Conn(), folder); err != nil {
+	if err := s.imageFolderRepo.Create(ctx, s.db, folder); err != nil {
 		return nil, err
 	}
 	return folder, nil
@@ -101,7 +101,7 @@ func (s *imageFolderService) List(ctx context.Context, parentID *uuid.UUID, limi
 		}
 	}
 
-	return s.imageFolderRepo.ListByParent(ctx, s.db.Conn(), parentID, limit, offset)
+	return s.imageFolderRepo.ListByParent(ctx, s.db, parentID, limit, offset)
 }
 
 func (s *imageFolderService) Rename(ctx context.Context, id uuid.UUID, newName string) error {
@@ -119,7 +119,7 @@ func (s *imageFolderService) Rename(ctx context.Context, id uuid.UUID, newName s
 		return err
 	}
 
-	return s.imageFolderRepo.Rename(ctx, s.db.Conn(), id, newName)
+	return s.imageFolderRepo.Rename(ctx, s.db, id, newName)
 }
 
 func (s *imageFolderService) Move(ctx context.Context, id uuid.UUID, targetParentID *uuid.UUID) error {
@@ -142,7 +142,7 @@ func (s *imageFolderService) Move(ctx context.Context, id uuid.UUID, targetParen
 		return err
 	}
 
-	return s.imageFolderRepo.Move(ctx, s.db.Conn(), id, targetParentID)
+	return s.imageFolderRepo.Move(ctx, s.db, id, targetParentID)
 }
 
 func (s *imageFolderService) Delete(ctx context.Context, id uuid.UUID) error {
@@ -150,10 +150,10 @@ func (s *imageFolderService) Delete(ctx context.Context, id uuid.UUID) error {
 	if err != nil {
 		return err
 	}
-	return s.imageFolderRepo.SoftDelete(ctx, s.db.Conn(), id)
+	return s.imageFolderRepo.SoftDelete(ctx, s.db, id)
 }
 
-func NewImageFolderService(db database.DB, imageFolderRepo repository.IImageFolderRepo) IImageFolderService {
+func NewImageFolderService(db database.Database, imageFolderRepo repository.IImageFolderRepo) IImageFolderService {
 	return &imageFolderService{
 		db:              db,
 		imageFolderRepo: imageFolderRepo,

--- a/backend/service/link.go
+++ b/backend/service/link.go
@@ -23,23 +23,23 @@ type ILinkService interface {
 }
 
 type linkService struct {
-	db       database.DB
+	db       database.Database
 	linkRepo repository.ILinkRepo
 }
 
 // NewLinkService creates a new link service instance
-func NewLinkService(db database.DB, linkRepo repository.ILinkRepo) ILinkService {
+func NewLinkService(db database.Database, linkRepo repository.ILinkRepo) ILinkService {
 	return &linkService{db: db, linkRepo: linkRepo}
 }
 
 // GetLinks retrieves all enabled links
 func (s *linkService) GetLinks(ctx context.Context) ([]*entity.Link, error) {
-	return s.linkRepo.GetAllEnabledLinks(ctx, s.db.Conn())
+	return s.linkRepo.GetAllEnabledLinks(ctx, s.db)
 }
 
 // GetOverview retrieves link statistics
 func (s *linkService) GetOverview(ctx context.Context) (*response.LinkOverview, error) {
-	return s.linkRepo.GetOverview(ctx, s.db.Conn())
+	return s.linkRepo.GetOverview(ctx, s.db)
 }
 
 // CreateLink creates a new link
@@ -50,13 +50,13 @@ func (s *linkService) CreateLink(ctx context.Context, dto *request.CreateLinkReq
 		Avatar:      dto.Avatar,
 		URL:         dto.URL,
 	}
-	return s.linkRepo.CreateLink(ctx, s.db.Conn(), &link)
+	return s.linkRepo.CreateLink(ctx, s.db, &link)
 }
 
 // CheckLinkStatus checks the status of all links by making HTTP requests
 // Updates the link status in the database if it has changed
 func (s linkService) CheckLinkStatus(ctx context.Context) error {
-	links, err := s.linkRepo.GetAllLinks(ctx, s.db.Conn())
+	links, err := s.linkRepo.GetAllLinks(ctx, s.db)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (s linkService) CheckLinkStatus(ctx context.Context) error {
 	}
 
 	wg.Wait()
-	err = s.linkRepo.UpdateLinkStatusBatch(ctx, s.db.Conn(), updates)
+	err = s.linkRepo.UpdateLinkStatusBatch(ctx, s.db, updates)
 	if err != nil {
 		return err
 	}

--- a/backend/service/post.go
+++ b/backend/service/post.go
@@ -25,29 +25,29 @@ type IPostService interface {
 
 type postService struct {
 	log      logger.Logger
-	db       database.DB
+	db       database.Database
 	rc       cache.CacheClient
 	postRepo repository.IPostRepo
 }
 
 // NewPostService creates a new post service instance
-func NewPostService(log logger.Logger, db database.DB, rc cache.CacheClient, postRepo repository.IPostRepo) IPostService {
+func NewPostService(log logger.Logger, db database.Database, rc cache.CacheClient, postRepo repository.IPostRepo) IPostService {
 	return &postService{log: log, db: db, rc: rc, postRepo: postRepo}
 }
 
 // GetPosts retrieves all published posts without content
 func (p *postService) GetPosts(ctx context.Context) ([]*entity.Post, error) {
-	return p.postRepo.GetAllPosts(ctx, p.db.Conn())
+	return p.postRepo.GetAllPosts(ctx, p.db)
 }
 
 // GetPostsWithContent retrieves all published posts with full content
 func (p *postService) GetPostsWithContent(ctx context.Context) ([]*entity.Post, error) {
-	return p.postRepo.GetAllPostsWithContent(ctx, p.db.Conn())
+	return p.postRepo.GetAllPostsWithContent(ctx, p.db)
 }
 
 // GetPostsMeta retrieves metadata (id and updated_at) for all posts
 func (p *postService) GetPostsMeta(ctx context.Context) []*entity.Post {
-	posts, err := p.postRepo.GetPostsMeta(ctx, p.db.Conn())
+	posts, err := p.postRepo.GetPostsMeta(ctx, p.db)
 	if err != nil {
 		p.log.Error("get posts meta failed", logger.Error(err))
 		return []*entity.Post{}
@@ -57,7 +57,7 @@ func (p *postService) GetPostsMeta(ctx context.Context) []*entity.Post {
 
 // GetPostByID retrieves a single published post by ID and increments the view count in Redis
 func (p *postService) GetPostByID(ctx context.Context, id uint) (*entity.Post, error) {
-	post, err := p.postRepo.GetPostByID(ctx, p.db.Conn(), id)
+	post, err := p.postRepo.GetPostByID(ctx, p.db, id)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (p *postService) FlushViewCountToDB(ctx context.Context) error {
 		}
 
 		if len(updates) > 0 {
-			if err := p.postRepo.UpdateViewCounts(ctx, p.db.Conn(), updates); err != nil {
+			if err := p.postRepo.UpdateViewCounts(ctx, p.db, updates); err != nil {
 				allErrors = append(allErrors, fmt.Errorf("db update failed: %w", err))
 			}
 		}

--- a/backend/service/rss.go
+++ b/backend/service/rss.go
@@ -19,12 +19,12 @@ type IRssService interface {
 
 type rssService struct {
 	cfg      config.AppConfig
-	db       database.DB
+	db       database.Database
 	postRepo repository.IPostRepo
 }
 
 func (r *rssService) GenerateRSSFeedXML(ctx context.Context) ([]byte, error) {
-	posts, err := r.postRepo.GetAllPosts(ctx, r.db.Conn())
+	posts, err := r.postRepo.GetAllPosts(ctx, r.db)
 	if err != nil {
 		return nil, err
 	}
@@ -75,6 +75,6 @@ func (r *rssService) GenerateRSSFeedXML(ctx context.Context) ([]byte, error) {
 	return xml.MarshalIndent(feed, "", "  ")
 }
 
-func NewRssService(cfg *config.Config, db database.DB, postRepo repository.IPostRepo) IRssService {
+func NewRssService(cfg *config.Config, db database.Database, postRepo repository.IPostRepo) IRssService {
 	return &rssService{cfg: cfg.App, db: db, postRepo: postRepo}
 }

--- a/backend/service/stats.go
+++ b/backend/service/stats.go
@@ -13,12 +13,12 @@ type IStatsService interface {
 }
 
 type statsService struct {
-	db       database.DB
+	db       database.Database
 	postRepo repository.IPostRepo
 }
 
 func (s *statsService) GetDashboardStats(ctx context.Context) (*response.DashboardStatsRes, error) {
-	postCount, err := s.postRepo.GetPostCount(ctx, s.db.Conn())
+	postCount, err := s.postRepo.GetPostCount(ctx, s.db)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (s *statsService) GetDashboardStats(ctx context.Context) (*response.Dashboa
 	}, nil
 }
 
-func NewStatsService(db database.DB, postRepo repository.IPostRepo) IStatsService {
+func NewStatsService(db database.Database, postRepo repository.IPostRepo) IStatsService {
 	return &statsService{
 		db,
 		postRepo,


### PR DESCRIPTION
- Replace `DB` with `Database`; redefine `TxContext` as interface-based transaction context
- Implement `GormDatabase` and `GormTxContext`
- Add helpers `ToGormDB`, `NewGormTxContext`, and repository `unwrapDB`
- Remove direct `*gorm.DB` exposure from public interfaces